### PR TITLE
Gist converting partially implemented 

### DIFF
--- a/lib/url_helper.js
+++ b/lib/url_helper.js
@@ -19,10 +19,12 @@ var REGEX = {
 // Methods
 
 /**
+ * Translate a Gist URL to a raw markdown URL
  * @return {promise}
  */
 function _translateGistMarkdownUrl(gitprintPath, deferred) {
-  // TODO
+  var params = gitprintPath.match(REGEX.Gist);
+  return 'https://gist.githubusercontent.com/' + params[1] + '/raw/';
 }
 
 /**

--- a/routes/index.js
+++ b/routes/index.js
@@ -128,19 +128,18 @@ function _getMarkdownPreProcessors(url) {
 }
 
 exports.convertGistMarkdownToPdf = function(req, res) {
-  console.log("convertGistMarkdownToPdf");
+    var githubPath = req.path,
+        url = urlHelper.translate(githubPath),
+        qsParamKeys = Object.keys(req.query),
+        autoPrint = (qsParamKeys.indexOf('print') !== -1);
 
-  // // https://gist.githubusercontent.com
-  // var githubPath = '';
-  // 'https://gist.githubusercontent.com/' + githubPath;
-  
-  // if(Object.keys(req.query).indexOf('download') !== -1) {
-  //   convert(req, res, url, DISPOSITION.ATTACHMENT);
-  // } else if(Object.keys(req.query).indexOf('inline') !== -1) {
-  //   convert(req, res, url, DISPOSITION.INLINE);
-  // } else {
-  //   res.render('printView', { pageTitle: githubPath, autoPrint: autoPrint });
-  // }
+  if(Object.keys(req.query).indexOf('download') !== -1) {
+    convert(req, res, url, DISPOSITION.ATTACHMENT);
+  } else if(Object.keys(req.query).indexOf('inline') !== -1) {
+    convert(req, res, url, DISPOSITION.INLINE);
+  } else {
+    res.render('printView', { pageTitle: githubPath, autoPrint: autoPrint });
+  }
 };
 
 exports.convertWikiMarkdownToPdf = function(req, res){


### PR DESCRIPTION
This is only a partial implementation, reusing much of what was already implemented of the gist support, and as such does not interact with the Github Gists API at all. Ideally, the implementation would not stop here, but allow for users to specify a file within the gist, as a single gist can contain multiple files.

This implementation just takes the files as they come; if you request the [root url](https://gist.githubusercontent.com/Mause/c42665f6771fd2b79eb7/raw/f42dca0f58cecfc7c1becb2401700c6e3dd0cf83/api.py) it appears to only return the contents of the first file in the gist. As detailed in the [Gist API docs](https://developer.github.com/v3/gists/#get-a-single-gist) it is possible to get the urls for the other files within the gist, which would allow for users to select a single file to be converted.

On an aside, much of most of the url handlers are near identical; probably wouldn't be a bad idea to refactor them into a single function :smile: 
